### PR TITLE
further fix  for Float32 bisect infinite loop

### DIFF
--- a/src/linesearches.jl
+++ b/src/linesearches.jl
@@ -102,7 +102,7 @@ function bisect(iter::HagerZhangLineSearchIterator, a::LineSearchPoint, b::LineS
     fmax = p₀.f + ϵ
     numfg = 0
     while true
-        if (b.α - a.α) <= eps(b.α)
+        if (b.α - a.α) <= eps(max(b.α, one(b.α)))
             if iter.parameters.verbosity > 0
                 @warn @sprintf("Linesearch bisection failure: [a, b] = [%.2e, %.2e], b-a = %.2e, dϕᵃ = %.2e, dϕᵇ = %.2e, (ϕᵇ - ϕᵃ)/(b-a) = %.2e", a.α, b.α, b.α - a.α, a.dϕ, b.dϕ, (b.ϕ - a.ϕ)/(b.α - a.α))
             end

--- a/src/linesearches.jl
+++ b/src/linesearches.jl
@@ -102,7 +102,7 @@ function bisect(iter::HagerZhangLineSearchIterator, a::LineSearchPoint, b::LineS
     fmax = p₀.f + ϵ
     numfg = 0
     while true
-        if (b.α - a.α) <= eps(typeof(b.α))
+        if (b.α - a.α) <= eps(b.α)
             if iter.parameters.verbosity > 0
                 @warn @sprintf("Linesearch bisection failure: [a, b] = [%.2e, %.2e], b-a = %.2e, dϕᵃ = %.2e, dϕᵇ = %.2e, (ϕᵇ - ϕᵃ)/(b-a) = %.2e", a.α, b.α, b.α - a.α, a.dϕ, b.dϕ, (b.ϕ - a.ϕ)/(b.α - a.α))
             end

--- a/src/linesearches.jl
+++ b/src/linesearches.jl
@@ -102,7 +102,7 @@ function bisect(iter::HagerZhangLineSearchIterator, a::LineSearchPoint, b::LineS
     fmax = p₀.f + ϵ
     numfg = 0
     while true
-        if b.α - a.α < eps(typeof(b.α))
+        if (b.α - a.α) <= eps(typeof(b.α))
             if iter.parameters.verbosity > 0
                 @warn @sprintf("Linesearch bisection failure: [a, b] = [%.2e, %.2e], b-a = %.2e, dϕᵃ = %.2e, dϕᵇ = %.2e, (ϕᵇ - ϕᵃ)/(b-a) = %.2e", a.α, b.α, b.α - a.α, a.dϕ, b.dϕ, (b.ϕ - a.ϕ)/(b.α - a.α))
             end


### PR DESCRIPTION
I just ran into a case that was infinite looping because `(b.α - a.α)` exactly equaled `eps(Float32)` and each successive iteration didn't change `b.α` or `a.α`. This seems to fix it. 

As an aside, out of curiousity, but is there one of the HagerZhangLineSearch parameters I can change to make the linesearch not try so hard to get a step-size to machine precision (which I doubt I really need)? I'm not really familiar with the algorithm so don't know what its various parameters do.  