### PR TITLE
Set up basic documentation

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,38 @@
+name: Documentation
+
+permissions:
+  contents: write
+  pages: write
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - '1' # automatically expands to the latest stable 1.x release of Julia
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v5
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
+        run: julia --project=docs/ docs/make.jl

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+OptimKit = "77e91f04-9b3b-57a6-a776-40b61faaebe0"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,27 @@
+using OptimKit
+using Documenter
+
+mathengine = MathJax3(
+    Dict(
+        :loader => Dict("load" => ["[tex]/physics"]),
+        :tex => Dict(
+            "inlineMath" => [["\$", "\$"], ["\\(", "\\)"]],
+            "tags" => "ams",
+            "packages" => ["base", "ams", "autoload", "physics"]
+        )
+    )
+)
+makedocs(;
+    sitename = "OptimKit.jl",
+    format = Documenter.HTML(;
+        prettyurls = true,
+        mathengine,
+    ),
+    pages = [
+        "Home" => "index.md",
+        "Library" => "lib.md",
+    ],
+    checkdocs = :exports,
+)
+
+deploydocs(; repo = "github.com/Jutho/OptimKit.jl.git")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,18 +1,5 @@
 # OptimKit.jl
 
-| **Documentation** | **Build Status** |
-|:-----------------:|:----------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] | [![CI][ci-img]][ci-url] |
-
-[docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg
-[docs-stable-url]: https://jutho.github.io/OptimKit.jl/stable
-
-[docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
-[docs-dev-url]: https://jutho.github.io/OptimKit.jl/latest
-
-[ci-img]: https://github.com/Jutho/OptimKit.jl/actions/workflows/ci.yml/badge.svg
-[ci-url]: https://github.com/Jutho/OptimKit.jl/actions/workflows/ci.yml
-
 A blissfully ignorant Julia package for optimization and fixed-point iteration.
 
 OptimKit is designed to make as few assumptions as possible about your state type and

--- a/docs/src/lib.md
+++ b/docs/src/lib.md
@@ -1,0 +1,5 @@
+# Library documentation
+
+```@autodocs
+Modules = [OptimKit]
+```

--- a/src/OptimKit.jl
+++ b/src/OptimKit.jl
@@ -99,8 +99,7 @@ The keyword arguments are:
 Check the README of this package for further details on creating an algorithm instance,
 as well as for the meaning of the remaining keyword arguments and their default values.
 
-!!! Warning
-    
+!!! warning
     The default values of `hasconverged` and `shouldstop` are provided to ensure continuity
     with the previous versions of this package. However, this behaviour might change in the
     future.
@@ -149,8 +148,7 @@ The keyword arguments are:
 Check the README of this package for further details on creating an algorithm instance,
 as well as for the meaning of the remaining keyword arguments and their default values.
 
-!!! Warning
-    
+!!! warning
     The default values of `hasconverged` and `shouldstop` are provided to ensure continuity
     with the previous versions of this package. However, this behaviour might change in the
     future.

--- a/src/anderson.jl
+++ b/src/anderson.jl
@@ -8,7 +8,8 @@
 
 Anderson mixing, also known as Anderson acceleration, for fixed point problems.
 
-WARNING: Experimental implementation – subject to change.
+!!! warning
+    Experimental implementation – subject to change.
 
 ## Parameters
 - `m::Int`: The number of previous iterates to use for Anderson extrapolation.


### PR DESCRIPTION
While the README has had a very helpful update recently, I think it would be good to additionally have some basic library documentation which at least collects all the docstrings. In particular, this would make it possible to directly refer to OptimKit.jl methods using DocumenterInterLinks.jl, which would be very helpful in MPSKit.jl and PEPSKit.jl.

I checked the build locally, but the github pages will have to be set up after merging to actually get things published.